### PR TITLE
Fixed the bug about Position Type Doesn't work

### DIFF
--- a/RMessage/RMessageView.m
+++ b/RMessage/RMessageView.m
@@ -1039,6 +1039,10 @@ static NSMutableDictionary *globalDesignDictionary;
   [self layoutIfNeeded];
 
   UINavigationController *messageNavigationController = [self rootNavigationController];
+ 
+  if ([self.superview.constraints containsObject:self.topToVCFinalConstraint]) {
+      [self.superview removeConstraint:self.topToVCFinalConstraint];
+  }
 
   if (messageNavigationController) {
     BOOL messageNavigationBarHidden =
@@ -1064,12 +1068,14 @@ static NSMutableDictionary *globalDesignDictionary;
     }
   } else {
     if (self.messagePosition == RMessagePositionBottom) {
-      [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.superview attribute:NSLayoutAttributeBottom multiplier:1.f constant:0.f];
+      self.topToVCFinalConstraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.superview attribute:NSLayoutAttributeBottom multiplier:1.f constant:0.f];
     } else {
       self.topToVCFinalConstraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.superview attribute:NSLayoutAttributeTop multiplier:1.f constant:0.f];
     }
     self.topToVCFinalConstraint.constant = - [self customVerticalOffset];
   }
+    
+  [self.superview addConstraint:self.topToVCFinalConstraint];
 }
 
 - (void)animateMessage


### PR DESCRIPTION
I think the latest version 2.2.1 has a bug for RMessagePosition
For example, here is my code:
`[RMessage showNotificationInViewController:self.bannerMessageDisplayingVC
                                                                                  title:title
                                                                               subtitle:message
                                                                              iconImage:nil
                                                                                   type:(RMessageType)bannerType
                                                                         customTypeName:@""
                                                                               duration:self.bannerShowingTime
                                                                               callback:nil
                                                                            buttonTitle:nil
                                                                         buttonCallback:nil
                                                                             atPosition:RMessagePositionBottom
                                                                   canBeDismissedByUser:YES];`

And here is what happen when the banner show up.
![simulator screen shot - iphone 8 plus - 2018-03-14 at 15 58 29](https://user-images.githubusercontent.com/13247012/37384156-5b696c58-27a1-11e8-9902-106af12eab11.png)
![simulator screen shot - iphone 8 plus - 2018-03-14 at 15 58 30](https://user-images.githubusercontent.com/13247012/37384162-5ffa3054-27a1-11e8-89ac-92e0963e6fdf.png)

And After my fix, it show up properly:
![simulator screen shot - iphone 8 plus - 2018-03-14 at 16 04 57](https://user-images.githubusercontent.com/13247012/37384190-8028d6e6-27a1-11e8-8ea6-ef59e642121c.png)
