### PR TITLE
Bugfix: tap-, present- and dismiss-completion handlers are now working

### DIFF
--- a/Sources/RMPresenter/RMPresenter.swift
+++ b/Sources/RMPresenter/RMPresenter.swift
@@ -69,12 +69,15 @@ import UIKit
   init(
     message: RMessage, targetPosition: RMessagePosition, animator: RMAnimator,
     animationOptions animationOpts: RMAnimationOptions,
-    tapCompletion _: (() -> Void)? = nil, presentCompletion _: (() -> Void)? = nil, dismissCompletion _: (() -> Void)? = nil
+    tapCompletion: (() -> Void)? = nil, presentCompletion: (() -> Void)? = nil, dismissCompletion: (() -> Void)? = nil
   ) {
     self.message = message
     self.targetPosition = targetPosition
     self.animator = animator
     self.animationOpts = animationOpts
+    self.tapCompletion = tapCompletion
+    self.presentCompletion = presentCompletion
+    self.dismissCompletion = dismissCompletion
     super.init()
     setupAnimator()
     setupGestureRecognizers()


### PR DESCRIPTION
As the completion handlers are not set at all, they can't be called for the related events.
Now the completion closures (given as parameter) are saved in the init function and could be called later on.