### PR TITLE
Fix infinite loop & Avoid UIAlertController

### DIFF
--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -25,7 +25,6 @@ class DemoViewController: UIViewController, RMControllerDelegate {
     /* Normally we would set the default view controller and delegate in viewDidLoad
      but since we are using this view controller for our modal view also it is important to properly
      re-set the variables once the modal dismisses. */
-    rControl.presentationViewController = self
     rControl.delegate = self
   }
 

--- a/Demo/DemoViewController.swift
+++ b/Demo/DemoViewController.swift
@@ -277,6 +277,20 @@ class DemoViewController: UIViewController, RMControllerDelegate {
     perform(#selector(didTapMessage(_:)), with: nil, afterDelay: 3.0)
   }
 
+  @IBAction func whilstAlertTapped(_: Any) {
+    let alert = UIAlertController(title: "An Alert", message: "Something is going on", preferredStyle: .alert)
+
+    let action = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+
+    alert.addAction(action)
+
+    present(alert, animated: true, completion: nil)
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
+      self.rControl.showMessage(withSpec: normalSpec, title: "Showing whilst an alert is visible")
+    }
+  }
+
   @objc func buttonTapped() {
     print("button was tapped")
   }

--- a/Demo/UI Assets/Main.storyboard
+++ b/Demo/UI Assets/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PwW-8b-w6J">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PwW-8b-w6J">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,7 +15,7 @@
             <objects>
                 <viewController title="Normal" id="h0s-uL-LZy" customClass="DemoViewController" customModule="RMessageDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dND-ej-UHz">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xp9-HB-Zsl">
@@ -244,6 +245,15 @@
                                 </state>
                                 <connections>
                                     <action selector="didTapTapOnlyDismissal:" destination="h0s-uL-LZy" eventType="touchUpInside" id="SVf-Cm-970"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fMh-xh-ZK9">
+                                <rect key="frame" x="273" y="518" width="76" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <state key="normal" title="Whilst Alert"/>
+                                <connections>
+                                    <action selector="whilstAlertTapped:" destination="h0s-uL-LZy" eventType="touchUpInside" id="DGN-wl-Xaj"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -484,6 +494,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="doggy" width="320" height="193"/>
+        <image name="doggy" width="46080" height="27864"/>
     </resources>
 </document>

--- a/Sources/General Extensions/UIWindow+ViewController.swift
+++ b/Sources/General Extensions/UIWindow+ViewController.swift
@@ -15,15 +15,16 @@ extension UIWindow {
   /// - Parameter viewController: The view controller from which to start traversing.
   /// - Returns: The top view controller in the window.
   static func topViewController(forViewController viewController: UIViewController) -> UIViewController {
-    if viewController.presentingViewController != nil {
-      return topViewController(forViewController: viewController.presentingViewController!)
+    if let presented = viewController.presentedViewController {
+      return topViewController(forViewController: presented)
     } else if let navigationController = viewController as? UINavigationController,
-      let visibleVCInNavigationVC = navigationController.visibleViewController {
-      return topViewController(forViewController: visibleVCInNavigationVC)
+      let topVCInNavigationVC = navigationController.topViewController {
+      return topViewController(forViewController: topVCInNavigationVC)
     } else if let tabBarController = viewController as? UITabBarController,
       let selectedVCInTabBarVC = tabBarController.selectedViewController {
       return topViewController(forViewController: selectedVCInTabBarVC)
     }
+    
     return viewController
   }
 

--- a/Sources/General Extensions/UIWindow+ViewController.swift
+++ b/Sources/General Extensions/UIWindow+ViewController.swift
@@ -15,7 +15,7 @@ extension UIWindow {
   /// - Parameter viewController: The view controller from which to start traversing.
   /// - Returns: The top view controller in the window.
   static func topViewController(forViewController viewController: UIViewController) -> UIViewController {
-    if let presented = viewController.presentedViewController {
+    if let presented = viewController.presentedViewController, !presented.isKind(of: UIAlertController.self) {
       return topViewController(forViewController: presented)
     } else if let navigationController = viewController as? UINavigationController,
       let topVCInNavigationVC = navigationController.topViewController {
@@ -24,7 +24,7 @@ extension UIWindow {
       let selectedVCInTabBarVC = tabBarController.selectedViewController {
       return topViewController(forViewController: selectedVCInTabBarVC)
     }
-    
+
     return viewController
   }
 

--- a/UITests/NavigationControllerTests.swift
+++ b/UITests/NavigationControllerTests.swift
@@ -184,6 +184,10 @@ class NavigationControllerTests: XCTestCase {
     showMessageFromTopByPressingButton(withName: "Custom image", hidingNavBar: false, timeToShow: 3.0, timeToHide: 8.0)
   }
 
+  func testWhilstAlert() {
+    showMessageFromTopByPressingButton(withName: "Whilst Alert", hidingNavBar: false, timeToShow: 3.0, timeToHide: 8.0)
+  }
+
   func testEndlessMessageNoNavBar() {
     showEndlessMessage(hidingNavBar: false, withTimeout: 3.0)
   }


### PR DESCRIPTION
I noticed a change in the history of `topViewController` where `presentedViewController` was changed to `presentingViewController`. I'm not sure what this was intended to fix but it easily sends it into an infinite loop where it goes like this:

1. NavigationController
2. Modal (via `visibleViewController`)
3. back to NavigationController (via `presentingViewController`)
4. etc

The proposed changes are as follows:

1) Don't set the `presentationViewController` explicitely in the demo project and rely on the `topViewController` implementation instead - this way it gets tested as part of the UITests
2) Change `presentingViewController` back to `presentedViewController`
3) Stop using `visibleViewController` the nav controller (since the `presented` part is covered in the previous case) and just use `topViewController`
4) Additionally, make an exception for UIAlertControllers when going up the `presented` stack - it looks really strange when a message appears in an alert modal

Number 4 is probably not foolproof but does handle the most obvious cases. Let me know what you think. Thanks!

Hope this helps 😄 